### PR TITLE
Spinner transparency should be 0.1 for message to be readable

### DIFF
--- a/browser/app.css
+++ b/browser/app.css
@@ -44,7 +44,7 @@ footer {
   }
 
   .is-disabled {
-    opacity: .5;
+    opacity: 0.1;
     pointer-events: none;
   }
 

--- a/browser/pages/confirm/confirm.html
+++ b/browser/pages/confirm/confirm.html
@@ -4,16 +4,12 @@
 </header>
 
 <main class="col-sm-12 bottom-spacer" >
-  <p class="installation-note has-spinner" ng-show="!confCtrl.isDisabled">
-    <span class="pficon-info" ng-show="confCtrl.numberOfExistingInstallations>0"></span>
-    {{confCtrl.installedSearchNote}}
-    <br ng-show="confCtrl.numberOfExistingInstallations>0">
-    <span id="instructions" class="installation-instruction">
-      Select the components to install
-    </span>
-  </p>
-
   <form name="confirmForm" id="confirmForm" class="form-horizontal" ng-submit="confCtrl.install()" ng-class="{'is-disabled':confCtrl.isDisabled}">
+
+    <p class="installation-note has-spinner" ng-show="confCtrl.numberOfExistingInstallations>0">
+      <span class="pficon-info"></span>{{confCtrl.installedSearchNote}}
+    </p>
+    <p class="installation-note">Select the components to install</p>
 
     <!-- devstudio -->
     <div id="devstudio-panel" class="panel panel-default panel2pxborder" ng-hide="checkboxModel.devstudio === undefined" ng-class="{'zero-border':checkboxModel.devstudio.hasOption('detected')}">
@@ -494,7 +490,7 @@
     </div>
   </form>
 
-  <div  id="detection-info" class="centered has-spinner" ng-show="confCtrl.isDisabled" ng-class="{'active':confCtrl.isDisabled}">
+  <div id="detection-info" class="centered has-spinner" ng-show="confCtrl.isDisabled" ng-class="{'active':confCtrl.isDisabled}">
     <span class="spinner spinner-lg spinner-bgcolour spinner-inline"><i class="icon-spin icon-refresh"></i></span>
     <p class="installation-note">
       <div class="detection-msg">


### PR DESCRIPTION
Status messages bunder breadcrumb should be visible to avoid
somponent list jumping up after detection is over.